### PR TITLE
Remove png.h include and libpng dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ Spherical Quadrilateral Mesh Generator (SQuadGen)
 =================================================
 
 REQUIRED EXTERNAL LIBRARIES
-  libpng
   libnetcdf
 
 BUILDING

--- a/src/SQuadGen.cpp
+++ b/src/SQuadGen.cpp
@@ -14,7 +14,6 @@
 ///		or implied warranty.
 ///	</remarks>
 
-#include <png.h>
 #include "netcdfcpp.h"
 
 #include <string>


### PR DESCRIPTION
We determined in #6 and in my build on SQuadGen on conda-forge that they are not needed.

closes #6 